### PR TITLE
Update dependencies, Add salt to verifier API and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,31 +14,28 @@ rust-gmp = "0.5.0"
 rand = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
+curv = { package = "curv-kzen", version = "0.7" }
 
 [dependencies.paillier]
 git = "https://github.com/KZen-networks/rust-paillier"
-tag = "v0.3.4"
+tag = "v0.3.10"
 
 [dependencies.zk-paillier]
 git = "https://github.com/KZen-networks/zk-paillier"
-tag = "v0.2.8"
+tag = "v0.3.12"
 
 [dependencies.multi-party-schnorr]
 git = "https://github.com/KZen-networks/multi-party-schnorr"
-tag = "v0.3.2"
+tag = "v0.4.4"
 
-[dependencies.curv]
-git = "https://github.com/KZen-networks/curv"
-features =  ["ec_secp256k1"]
-tag = "v0.2.3"
 
 [dependencies.multi-party-ecdsa]
 git = "https://github.com/KZen-networks/multi-party-ecdsa"
-rev = "0a4931b8247b2f187dcb9ff7c7c096444feadcc3"
+tag = "v0.4.6"
 
 [dependencies.centipede]
 git = "https://github.com/KZen-networks/centipede"
-tag = "v0.2.2"
+tag = "v0.2.12"
 
 [patch.crates-io]
 rust-gmp = { version = "0.5.0", features = ["serde_support"], git = "https://github.com/KZen-networks/rust-gmp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kms"
-version = "0.2.2"
+version = "0.3.0"
 authors = [
     "Omer <omer@kzencorp.com>",
     "Gary <gary@kzencorp.com>"

--- a/src/chain_code/two_party/party1.rs
+++ b/src/chain_code/two_party/party1.rs
@@ -12,7 +12,8 @@
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
 use curv::elliptic::curves::traits::ECPoint;
-use curv::{BigInt, GE};
+use curv::BigInt;
+use curv::elliptic::curves::secp256_k1::GE;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ChainCode1 {
@@ -20,17 +21,17 @@ pub struct ChainCode1 {
 }
 
 impl ChainCode1 {
-    pub fn chain_code_first_message() -> (Party1FirstMessage, CommWitness, EcKeyPair) {
+    pub fn chain_code_first_message() -> (Party1FirstMessage, CommWitness<GE>, EcKeyPair<GE>) {
         Party1FirstMessage::create_commitments()
     }
     pub fn chain_code_second_message(
-        comm_witness: CommWitness,
-        proof: &DLogProof,
-    ) -> Party1SecondMessage {
+        comm_witness: CommWitness<GE>,
+        proof: &DLogProof<GE>,
+    ) -> Party1SecondMessage<GE> {
         Party1SecondMessage::verify_and_decommit(comm_witness, proof).expect("")
     }
     pub fn compute_chain_code(
-        ec_key_pair: &EcKeyPair,
+        ec_key_pair: &EcKeyPair<GE>,
         party2_first_message_public_share: &GE,
     ) -> ChainCode1 {
         ChainCode1 {

--- a/src/chain_code/two_party/party2.rs
+++ b/src/chain_code/two_party/party2.rs
@@ -13,7 +13,8 @@
 use curv::cryptographic_primitives::proofs::ProofError;
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
 use curv::elliptic::curves::traits::ECPoint;
-use curv::{BigInt, GE};
+use curv::BigInt;
+use curv::elliptic::curves::secp256_k1::GE;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ChainCode2 {
@@ -21,13 +22,13 @@ pub struct ChainCode2 {
 }
 
 impl ChainCode2 {
-    pub fn chain_code_first_message() -> (Party2FirstMessage, EcKeyPair) {
+    pub fn chain_code_first_message() -> (Party2FirstMessage<GE>, EcKeyPair<GE>) {
         Party2FirstMessage::create()
     }
 
     pub fn chain_code_second_message(
         party_one_first_message: &Party1FirstMessage,
-        party_one_second_message: &Party1SecondMessage,
+        party_one_second_message: &Party1SecondMessage<GE>,
     ) -> Result<Party2SecondMessage, ProofError> {
         Party2SecondMessage::verify_commitments_and_dlog_proof(
             &party_one_first_message,
@@ -36,7 +37,7 @@ impl ChainCode2 {
     }
 
     pub fn compute_chain_code(
-        ec_key_pair: &EcKeyPair,
+        ec_key_pair: &EcKeyPair<GE>,
         party1_second_message_public_share: &GE,
     ) -> ChainCode2 {
         ChainCode2 {

--- a/src/ecdsa/two_party/mod.rs
+++ b/src/ecdsa/two_party/mod.rs
@@ -14,7 +14,9 @@ use curv::arithmetic::traits::Converter;
 use curv::cryptographic_primitives::hashing::hmac_sha512;
 use curv::cryptographic_primitives::hashing::traits::KeyedHash;
 use curv::elliptic::curves::traits::{ECPoint, ECScalar};
-use curv::{BigInt, FE, GE};
+use curv::BigInt;
+use curv::arithmetic::{BasicOps, One};
+use curv::elliptic::curves::secp256_k1::{FE, GE};
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::{party_one, party_two};
 use paillier::*;
 
@@ -72,7 +74,7 @@ pub fn hd_key(
     let f_l_fe: FE = ECScalar::from(&f_l);
     let f_r_fe: FE = ECScalar::from(&f_r);
 
-    let bn_to_slice = BigInt::to_vec(chain_code_bi);
+    let bn_to_slice = BigInt::to_bytes(chain_code_bi);
     let chain_code = GE::from_bytes(&bn_to_slice[1..33]).unwrap() * &f_r_fe;
     let pub_key = pubkey * &f_l_fe;
 

--- a/src/ecdsa/two_party/party1.rs
+++ b/src/ecdsa/two_party/party1.rs
@@ -12,7 +12,8 @@
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::elliptic::curves::traits::ECPoint;
 use curv::elliptic::curves::traits::ECScalar;
-use curv::{BigInt, FE, GE};
+use curv::BigInt;
+use curv::elliptic::curves::secp256_k1::{FE, GE};
 
 use super::hd_key;
 use super::{MasterKey1, MasterKey2, Party1Public};
@@ -169,7 +170,7 @@ impl MasterKey1 {
     pub fn key_gen_second_message(
         comm_witness: party_one::CommWitness,
         ec_key_pair_party1: &party_one::EcKeyPair,
-        proof: &DLogProof,
+        proof: &DLogProof<GE>,
     ) -> (
         KeyGenParty1Message2,
         party_one::PaillierKeyPair,

--- a/src/ecdsa/two_party/party2.rs
+++ b/src/ecdsa/two_party/party2.rs
@@ -10,7 +10,8 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/kms/blob/master/LICENSE>
 */
 
-use curv::{BigInt, FE, GE};
+use curv::BigInt;
+use curv::elliptic::curves::secp256_k1::{FE, GE};
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_one::EphKeyGenFirstMsg as Party1EphKeyGenFirstMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_one::KeyGenFirstMsg as Party1KeyGenFirstMsg;
 

--- a/src/ecdsa/two_party/party2.rs
+++ b/src/ecdsa/two_party/party2.rs
@@ -158,6 +158,7 @@ impl MasterKey2 {
     pub fn key_gen_second_message(
         party_one_first_message: &Party1KeyGenFirstMsg,
         party_one_second_message: &KeyGenParty1Message2,
+        party_one_second_message_salt: &[u8]
     ) -> Result<(Party2SecondMessage, party_two::PaillierPublic), ()> {
         let paillier_encryption_key = party_one_second_message.ek.clone();
         let paillier_encrypted_share = party_one_second_message.c_key.clone();
@@ -186,7 +187,7 @@ impl MasterKey2 {
 
         let correct_key_verify = party_one_second_message
             .correct_key_proof
-            .verify(&party_two_paillier.ek);
+            .verify(&party_two_paillier.ek, party_one_second_message_salt);
 
         match pdl_verify {
             Ok(_proof) => match correct_key_verify {
@@ -247,6 +248,7 @@ impl MasterKey2 {
         self,
         cf: &Rotation,
         party_one_rotation_first_message: &RotationParty1Message1,
+        party_one_rotation_first_message_salt: &[u8]
     ) -> Result<MasterKey2, ()> {
         let party_two_paillier = party_two::PaillierPublic {
             ek: party_one_rotation_first_message.ek.clone(),
@@ -263,7 +265,7 @@ impl MasterKey2 {
 
         let correct_key_verify = party_one_rotation_first_message
             .correct_key_proof
-            .verify(&party_two_paillier.ek);
+            .verify(&party_two_paillier.ek, party_one_rotation_first_message_salt);
 
         let master_key = self.rotate(cf, &party_two_paillier);
 

--- a/src/ecdsa/two_party/test.rs
+++ b/src/ecdsa/two_party/test.rs
@@ -26,6 +26,7 @@ mod tests {
     use rotation::two_party::party1::Rotation1;
     use rotation::two_party::party2::Rotation2;
     use rotation::two_party::Rotation;
+    use zk_paillier::zkproofs::SALT_STRING;
 
     #[test]
     fn test_recovery_from_openssl() {
@@ -167,7 +168,7 @@ mod tests {
             party_one_master_key_half_recovered.rotation_first_message(&random1);
 
         let result_rotate_party_one_first_message =
-            party_two_master_key.rotate_first_message(&random2, &rotation_party_one_first_message);
+            party_two_master_key.rotate_first_message(&random2, &rotation_party_one_first_message, SALT_STRING);
         assert!(result_rotate_party_one_first_message.is_ok());
 
         let party_two_master_key_rotated = result_rotate_party_one_first_message.unwrap();
@@ -415,6 +416,7 @@ mod tests {
         let key_gen_second_message = MasterKey2::key_gen_second_message(
             &kg_party_one_first_message,
             &kg_party_one_second_message,
+            SALT_STRING
         );
 
         assert!(key_gen_second_message.is_ok());
@@ -486,7 +488,7 @@ mod tests {
             party_one_master_key.rotation_first_message(&random1);
 
         let result_rotate_party_two =
-            party_two_master_key.rotate_first_message(&random2, &rotation_party_one_first_message);
+            party_two_master_key.rotate_first_message(&random2, &rotation_party_one_first_message, SALT_STRING);
         assert!(result_rotate_party_two.is_ok());
 
         (

--- a/src/ecdsa/two_party/test.rs
+++ b/src/ecdsa/two_party/test.rs
@@ -20,7 +20,9 @@ mod tests {
     use chain_code::two_party::party2;
     use curv::arithmetic::traits::Converter;
     use curv::elliptic::curves::traits::{ECPoint, ECScalar};
-    use curv::{BigInt, FE, GE};
+    use curv::BigInt;
+    use curv::arithmetic::One;
+    use curv::elliptic::curves::secp256_k1::{FE, GE};
     use rotation::two_party::party1::Rotation1;
     use rotation::two_party::party2::Rotation2;
     use rotation::two_party::Rotation;
@@ -48,7 +50,7 @@ mod tests {
         let Y_hex = "2CFF67FA834F0E81E111F268624F2614C1B1E00BA93C4111773C1C248C5EA8FFF132E8EC3040D4DA67377F337D3866CB167A82AA0C4101ED\
         F5AD3F3898E7EB7C";
         let Y_bn = BigInt::from_str_radix(&Y_hex, 16).unwrap();
-        let Y_vec = BigInt::to_vec(&Y_bn);
+        let Y_vec = BigInt::to_bytes(&Y_bn);
         let Y: GE = ECPoint::from_bytes(&Y_vec[..]).unwrap();
 
         /*

--- a/src/poc.rs
+++ b/src/poc.rs
@@ -26,6 +26,7 @@ mod tests {
     use ecdsa::two_party::MasterKey2 as EcdsaMasterKey2;
     use schnorr::two_party::party1;
     use schnorr::two_party::party2;
+    use zk_paillier::zkproofs::SALT_STRING;
 
     #[test]
     fn poc_schnorr_ecdsa() {
@@ -88,6 +89,7 @@ mod tests {
         let key_gen_second_message = EcdsaMasterKey2::key_gen_second_message(
             &kg_party_one_first_message,
             &kg_party_one_second_message,
+            SALT_STRING,
         );
         assert!(key_gen_second_message.is_ok());
         // recovery party two:

--- a/src/poc.rs
+++ b/src/poc.rs
@@ -21,7 +21,7 @@ mod tests {
     use centipede::juggling::proof_system::Proof;
     use centipede::juggling::segmentation::Msegmentation;
     use curv::elliptic::curves::traits::{ECPoint, ECScalar};
-    use curv::{FE, GE};
+    use curv::elliptic::curves::secp256_k1::{FE, GE};
     use ecdsa::two_party::MasterKey1 as EcdsaMasterKey1;
     use ecdsa::two_party::MasterKey2 as EcdsaMasterKey2;
     use schnorr::two_party::party1;

--- a/src/rotation/two_party/mod.rs
+++ b/src/rotation/two_party/mod.rs
@@ -10,7 +10,7 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/kms/blob/master/LICENSE>
 */
 
-use curv::FE;
+use curv::elliptic::curves::secp256_k1::FE;
 
 pub mod party1;
 pub mod party2;

--- a/src/rotation/two_party/party1.rs
+++ b/src/rotation/two_party/party1.rs
@@ -11,14 +11,15 @@
 */
 use super::Rotation;
 use curv::cryptographic_primitives::twoparty::coin_flip_optimal_rounds;
-use curv::elliptic::curves::secp256_k1::Secp256k1Scalar;
+use curv::elliptic::curves::secp256_k1::{Secp256k1Scalar, GE};
+
 
 pub struct Rotation1 {}
 
 impl Rotation1 {
     //TODO: implmenet sid / state machine
     pub fn key_rotate_first_message() -> (
-        coin_flip_optimal_rounds::Party1FirstMessage,
+        coin_flip_optimal_rounds::Party1FirstMessage<GE>,
         Secp256k1Scalar,
         Secp256k1Scalar,
     ) {
@@ -26,10 +27,10 @@ impl Rotation1 {
     }
 
     pub fn key_rotate_second_message(
-        party2_first_message: &coin_flip_optimal_rounds::Party2FirstMessage,
+        party2_first_message: &coin_flip_optimal_rounds::Party2FirstMessage<GE>,
         m1: &Secp256k1Scalar,
         r1: &Secp256k1Scalar,
-    ) -> (coin_flip_optimal_rounds::Party1SecondMessage, Rotation) {
+    ) -> (coin_flip_optimal_rounds::Party1SecondMessage<GE>, Rotation) {
         let (res1, res2) = coin_flip_optimal_rounds::Party1SecondMessage::reveal(
             &party2_first_message.seed,
             m1,

--- a/src/rotation/two_party/party2.rs
+++ b/src/rotation/two_party/party2.rs
@@ -11,6 +11,7 @@
 */
 
 use curv::cryptographic_primitives::twoparty::coin_flip_optimal_rounds;
+use curv::elliptic::curves::secp256_k1::GE;
 
 use super::Rotation;
 
@@ -18,15 +19,15 @@ pub struct Rotation2 {}
 
 impl Rotation2 {
     pub fn key_rotate_first_message(
-        party1_first_message: &coin_flip_optimal_rounds::Party1FirstMessage,
-    ) -> coin_flip_optimal_rounds::Party2FirstMessage {
+        party1_first_message: &coin_flip_optimal_rounds::Party1FirstMessage<GE>,
+    ) -> coin_flip_optimal_rounds::Party2FirstMessage<GE> {
         coin_flip_optimal_rounds::Party2FirstMessage::share(&party1_first_message.proof)
     }
 
     pub fn key_rotate_second_message(
-        party1_second_message: &coin_flip_optimal_rounds::Party1SecondMessage,
-        party2_first_message: &coin_flip_optimal_rounds::Party2FirstMessage,
-        party1_first_message: &coin_flip_optimal_rounds::Party1FirstMessage,
+        party1_second_message: &coin_flip_optimal_rounds::Party1SecondMessage<GE>,
+        party2_first_message: &coin_flip_optimal_rounds::Party2FirstMessage<GE>,
+        party1_first_message: &coin_flip_optimal_rounds::Party1FirstMessage<GE>,
     ) -> Rotation {
         let rotation = coin_flip_optimal_rounds::finalize(
             &party1_second_message.proof,

--- a/src/schnorr/two_party/mod.rs
+++ b/src/schnorr/two_party/mod.rs
@@ -16,11 +16,12 @@
 
 use chain_code::two_party::party1::ChainCode1;
 use chain_code::two_party::party2::ChainCode2;
-use curv::arithmetic::traits::Converter;
 use curv::cryptographic_primitives::hashing::hmac_sha512;
 use curv::cryptographic_primitives::hashing::traits::KeyedHash;
 use curv::elliptic::curves::traits::{ECPoint, ECScalar};
-use curv::{BigInt, FE, GE};
+use curv::BigInt;
+use curv::arithmetic::{One, BasicOps, Converter};
+use curv::elliptic::curves::secp256_k1::{FE, GE};
 use multi_party_schnorr::protocols::multisig::KeyPair;
 // since this special case requires two out of two signers we ignore the "accountable" property
 
@@ -56,7 +57,7 @@ pub fn hd_key(
     let f_l_fe: FE = ECScalar::from(&f_l);
     let g: GE = ECPoint::generator();
     let f_r_fe: FE = ECScalar::from(&f_r);
-    let bn_to_slice = BigInt::to_vec(chain_code_bi);
+    let bn_to_slice = BigInt::to_bytes(chain_code_bi);
     let chain_code = GE::from_bytes(&bn_to_slice[1..33]).unwrap() * &f_r_fe;
     let pub_key = pubkey.clone() + &g * &f_l_fe;
 

--- a/src/schnorr/two_party/party1.rs
+++ b/src/schnorr/two_party/party1.rs
@@ -18,10 +18,11 @@ use super::hd_key;
 use super::{MasterKey1, MasterKey2};
 use chain_code::two_party::party1::ChainCode1;
 use chain_code::two_party::party2::ChainCode2;
-use curv::arithmetic::traits::Converter;
 use curv::elliptic::curves::traits::ECPoint;
 use curv::elliptic::curves::traits::ECScalar;
-use curv::{BigInt, FE, GE};
+use curv::BigInt;
+use curv::elliptic::curves::secp256_k1::{FE, GE};
+use curv::arithmetic::Converter;
 use multi_party_schnorr::protocols::multisig::*;
 use rotation::two_party::Rotation;
 use schnorr::two_party::party2::{
@@ -139,7 +140,7 @@ impl MasterKey1 {
         let (_It, Xt, es) = EphKey::compute_joint_comm_e(
             vec![self.pubkey.clone()],
             eph_pub_key_vec,
-            &BigInt::to_vec(message),
+            &BigInt::to_bytes(message),
         );
         let y1 = eph_sign
             .eph_key

--- a/src/schnorr/two_party/party2.rs
+++ b/src/schnorr/two_party/party2.rs
@@ -18,10 +18,11 @@ use super::hd_key;
 use super::{MasterKey1, MasterKey2};
 use chain_code::two_party::party1::ChainCode1;
 use chain_code::two_party::party2::ChainCode2;
-use curv::arithmetic::traits::Converter;
 use curv::elliptic::curves::traits::ECPoint;
 use curv::elliptic::curves::traits::ECScalar;
-use curv::{BigInt, FE, GE};
+use curv::BigInt;
+use curv::elliptic::curves::secp256_k1::{FE, GE};
+use curv::arithmetic::Converter;
 use multi_party_schnorr::protocols::multisig::*;
 use rotation::two_party::Rotation;
 use schnorr::two_party::party1::{
@@ -137,7 +138,7 @@ impl MasterKey2 {
         let (_It, Xt, es) = EphKey::compute_joint_comm_e(
             vec![self.pubkey.clone()],
             eph_pub_key_vec,
-            &BigInt::to_vec(message),
+            &BigInt::to_bytes(message),
         );
         let y2 = eph_sign
             .eph_key

--- a/src/schnorr/two_party/test.rs
+++ b/src/schnorr/two_party/test.rs
@@ -23,7 +23,8 @@ mod tests {
     use chain_code::two_party::party2::ChainCode2;
     use curv::elliptic::curves::traits::ECPoint;
     use curv::elliptic::curves::traits::ECScalar;
-    use curv::{BigInt, FE, GE};
+    use curv::BigInt;
+    use curv::elliptic::curves::secp256_k1::{FE, GE};
     use rotation::two_party::party1::Rotation1;
     use rotation::two_party::party2::Rotation2;
     use schnorr::two_party::{party1, party2};


### PR DESCRIPTION
Please review https://github.com/ZenGo-X/kms-secp256k1/commit/9b4eb11774ba4ecc65e0cb10560aff69384bf9ef more carefully as it has design implications,
in the prover we use `Option<&[u8]>` and default to `SALT_STRING`(and I don't think we have any explicit relationship between that option and the default) but in the verifier we require them to explicitly pass in the salt